### PR TITLE
Explicit nulls changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -494,5 +494,5 @@ lazy val docs = project.in(file("docs"))
 
 lazy val dottySettings = List(
   libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),
-  scalacOptions := List("-language:Scala2,implicitConversions", "-Xignore-scala2-macros", "-Yexplicit-nulls")
+  scalacOptions := List("-language:Scala2,implicitConversions", "-Xignore-scala2-macros", "-Yexplicit-nulls", "-Yjava-interop-dont-nullify-outermost")
 )

--- a/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/DescriptorImplicits.scala
@@ -940,7 +940,7 @@ class DescriptorImplicits(params: GeneratorParams, files: Seq[FileDescriptor]) {
   }
 
   def baseName(fileName: String) =
-    fileName.split("/").last.replaceAll(raw"[.]proto$$|[.]protodevel", "")
+    fileName.split("/").last.nn.replaceAll(raw"[.]proto$$|[.]protodevel", "")
 }
 
 private[scalapb] object DescriptorImplicits {

--- a/compiler-plugin/src/main/scala/scalapb/compiler/FunctionalPrinter.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/FunctionalPrinter.scala
@@ -41,7 +41,7 @@ case class FunctionalPrinter(content: Vector[String] = Vector.empty, indentLevel
 
   // Strips the margin, splits lines and adds.
   def addStringMargin(s: String): FunctionalPrinter =
-    add(s.stripMargin.split("\n", -1).toSeq: _*)
+    add(s.stripMargin.split("\n", -1).map(_.nn).toSeq: _*)
 
   // Adds the strings, while putting a delimiter between two lines.
   def addWithDelimiter(delimiter: String)(s: Seq[String]) = {

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -1874,7 +1874,7 @@ object ProtobufGenerator {
     request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
       case (acc, fp) =>
         val deps = fp.getDependencyList.asScala.map(acc)
-        acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray[FileDescriptor | JavaNull]))
+        acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray[FileDescriptor | Null]))
     }
 
   def handleCodeGeneratorRequest(request: CodeGeneratorRequest): CodeGeneratorResponse = {
@@ -1886,7 +1886,7 @@ object ProtobufGenerator {
             request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
               case (acc, fp) =>
                 val deps = fp.getDependencyList.asScala.map(acc)
-                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray[FileDescriptor | JavaNull]))
+                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray[FileDescriptor | Null]))
             }
           val implicits = new DescriptorImplicits(params, filesByName.values.toVector)
           val generator = new ProtobufGenerator(params, implicits)

--- a/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/scalapb/compiler/ProtobufGenerator.scala
@@ -1851,7 +1851,7 @@ object ProtobufGenerator {
   def parseParameters(params: String): Either[String, GeneratorParams] = {
     params
       .split(",")
-      .map(_.trim)
+      .map(_.nn.trim)
       .filter(_.nonEmpty)
       .foldLeft[Either[String, GeneratorParams]](Right(GeneratorParams())) {
         case (Right(params), "java_conversions") => Right(params.copy(javaConversions = true))
@@ -1874,7 +1874,7 @@ object ProtobufGenerator {
     request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
       case (acc, fp) =>
         val deps = fp.getDependencyList.asScala.map(acc)
-        acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
+        acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray[FileDescriptor | JavaNull]))
     }
 
   def handleCodeGeneratorRequest(request: CodeGeneratorRequest): CodeGeneratorResponse = {
@@ -1886,7 +1886,7 @@ object ProtobufGenerator {
             request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
               case (acc, fp) =>
                 val deps = fp.getDependencyList.asScala.map(acc)
-                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
+                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray[FileDescriptor | JavaNull]))
             }
           val implicits = new DescriptorImplicits(params, filesByName.values.toVector)
           val generator = new ProtobufGenerator(params, implicits)

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Grpc.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Grpc.scala
@@ -12,8 +12,8 @@ object Grpc {
     Futures.addCallback(
       guavaFuture,
       new FutureCallback[A] {
-        override def onFailure(t: Throwable): Unit = p.failure(t)
-        override def onSuccess(a: A): Unit         = p.success(a)
+        override def onFailure(t: Throwable | Null): Unit = p.failure(t.nn)
+        override def onSuccess(a: A | Null): Unit         = p.success(a.nn)
       },
       MoreExecutors.directExecutor()
     )

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Marshaller.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Marshaller.scala
@@ -6,21 +6,21 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message, TypeMapper
 
 class Marshaller[T <: GeneratedMessage with Message[T]](companion: GeneratedMessageCompanion[T])
     extends io.grpc.MethodDescriptor.Marshaller[T] {
-  override def stream(t: T): InputStream = new ByteArrayInputStream(t.toByteArray)
+  override def stream(t: T | JavaNull): InputStream = new ByteArrayInputStream(t.toByteArray)
 
-  override def parse(inputStream: InputStream): T =
-    companion.parseFrom(inputStream)
+  override def parse(inputStream: InputStream | JavaNull): T =
+    companion.parseFrom(inputStream.nn)
 }
 
 class TypeMappedMarshaller[T <: GeneratedMessage with Message[T], Custom](
     typeMapper: TypeMapper[T, Custom],
     companion: GeneratedMessageCompanion[T]
 ) extends io.grpc.MethodDescriptor.Marshaller[Custom] {
-  override def stream(t: Custom): InputStream =
-    new ByteArrayInputStream(typeMapper.toBase(t).toByteArray)
+  override def stream(t: Custom | JavaNull): InputStream =
+    new ByteArrayInputStream(typeMapper.toBase(t.nn).toByteArray)
 
-  override def parse(inputStream: InputStream): Custom =
-    typeMapper.toCustom(companion.parseFrom(inputStream))
+  override def parse(inputStream: InputStream | JavaNull): Custom =
+    typeMapper.toCustom(companion.parseFrom(inputStream.nn))
 }
 
 object Marshaller {

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Marshaller.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/Marshaller.scala
@@ -6,9 +6,9 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message, TypeMapper
 
 class Marshaller[T <: GeneratedMessage with Message[T]](companion: GeneratedMessageCompanion[T])
     extends io.grpc.MethodDescriptor.Marshaller[T] {
-  override def stream(t: T | JavaNull): InputStream = new ByteArrayInputStream(t.toByteArray)
+  override def stream(t: T | Null): InputStream = new ByteArrayInputStream(t.nn.toByteArray)
 
-  override def parse(inputStream: InputStream | JavaNull): T =
+  override def parse(inputStream: InputStream | Null): T =
     companion.parseFrom(inputStream.nn)
 }
 
@@ -16,10 +16,10 @@ class TypeMappedMarshaller[T <: GeneratedMessage with Message[T], Custom](
     typeMapper: TypeMapper[T, Custom],
     companion: GeneratedMessageCompanion[T]
 ) extends io.grpc.MethodDescriptor.Marshaller[Custom] {
-  override def stream(t: Custom | JavaNull): InputStream =
+  override def stream(t: Custom | Null): InputStream =
     new ByteArrayInputStream(typeMapper.toBase(t.nn).toByteArray)
 
-  override def parse(inputStream: InputStream | JavaNull): Custom =
+  override def parse(inputStream: InputStream | Null): Custom =
     typeMapper.toCustom(companion.parseFrom(inputStream.nn))
 }
 

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ProtoUtils.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ProtoUtils.scala
@@ -8,11 +8,11 @@ object ProtoUtils {
   class ScalaPbMetadataMarshaller[T <: GeneratedMessage with Message[T]](
       companion: GeneratedMessageCompanion[T]
   ) extends Metadata.BinaryMarshaller[T] {
-    override def toBytes(value: T): Array[Byte] = value.toByteArray
+    override def toBytes(value: T | JavaNull): Array[Byte] = value.nn.toByteArray
 
-    override def parseBytes(serialized: Array[Byte]): T = {
+    override def parseBytes(serialized: Array[Byte] | JavaNull): T = {
       try {
-        companion.parseFrom(serialized)
+        companion.parseFrom(serialized.nn)
       } catch {
         case ipbe: InvalidProtocolBufferException =>
           throw new IllegalArgumentException(ipbe)

--- a/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ProtoUtils.scala
+++ b/scalapb-runtime-grpc/src/main/scala/scalapb/grpc/ProtoUtils.scala
@@ -8,9 +8,9 @@ object ProtoUtils {
   class ScalaPbMetadataMarshaller[T <: GeneratedMessage with Message[T]](
       companion: GeneratedMessageCompanion[T]
   ) extends Metadata.BinaryMarshaller[T] {
-    override def toBytes(value: T | JavaNull): Array[Byte] = value.nn.toByteArray
+    override def toBytes(value: T | Null): Array[Byte] = value.nn.toByteArray
 
-    override def parseBytes(serialized: Array[Byte] | JavaNull): T = {
+    override def parseBytes(serialized: Array[Byte] | Null): T = {
       try {
         companion.parseFrom(serialized.nn)
       } catch {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Api.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Api.scala
@@ -30,14 +30,14 @@ import _root_.scalapb.internal.compat.JavaConverters._
   *   major version is derived from the package name, as outlined below. If the
   *   field is not empty, the version in the package name will be verified to be
   *   consistent with what is provided here.
-  *  
+  *
   *   The versioning schema uses [semantic
   *   versioning](http://semver.org) where the major version number
   *   indicates a breaking change and the minor version an additive,
   *   non-breaking change. Both version numbers are signals to users
   *   what to expect from different versions, and should be carefully
   *   chosen based on the product plan.
-  *  
+  *
   *   The major version is also reflected in the package name of the
   *   interface, which must end in `v&lt;major-version&gt;`, as in
   *   `google.feature.v1`. For major versions 0 and 1, the suffix can
@@ -65,7 +65,7 @@ final case class Api(
     private[this] var __serializedSizeCachedValue: _root_.scala.Int = 0
     private[this] def __computeSerializedValue(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = name
         if (__value != "") {
@@ -80,7 +80,7 @@ final case class Api(
         val __value = __item
         __size += 1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       }
-      
+
       {
         val __value = version
         if (__value != "") {
@@ -95,7 +95,7 @@ final case class Api(
         val __value = __item
         __size += 1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       }
-      
+
       {
         val __value = syntax
         if (__value != com.google.protobuf.`type`.Syntax.SYNTAX_PROTO2) {
@@ -302,14 +302,14 @@ object Api extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.Api
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = ApiProto.javaDescriptor.getMessageTypes.get(0)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = ApiProto.scalaDescriptor.messages(0)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.api.Method
       case 3 => __out = com.google.protobuf.`type`.OptionProto
       case 5 => __out = com.google.protobuf.source_context.SourceContext
       case 6 => __out = com.google.protobuf.api.Mixin
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Method.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/api/Method.scala
@@ -37,35 +37,35 @@ final case class Method(
     private[this] var __serializedSizeCachedValue: _root_.scala.Int = 0
     private[this] def __computeSerializedValue(): _root_.scala.Int = {
       var __size = 0
-      
+
       {
         val __value = name
         if (__value != "") {
           __size += _root_.com.google.protobuf.CodedOutputStream.computeStringSize(1, __value)
         }
       };
-      
+
       {
         val __value = requestTypeUrl
         if (__value != "") {
           __size += _root_.com.google.protobuf.CodedOutputStream.computeStringSize(2, __value)
         }
       };
-      
+
       {
         val __value = requestStreaming
         if (__value != false) {
           __size += _root_.com.google.protobuf.CodedOutputStream.computeBoolSize(3, __value)
         }
       };
-      
+
       {
         val __value = responseTypeUrl
         if (__value != "") {
           __size += _root_.com.google.protobuf.CodedOutputStream.computeStringSize(4, __value)
         }
       };
-      
+
       {
         val __value = responseStreaming
         if (__value != false) {
@@ -76,7 +76,7 @@ final case class Method(
         val __value = __item
         __size += 1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
       }
-      
+
       {
         val __value = syntax
         if (__value != com.google.protobuf.`type`.Syntax.SYNTAX_PROTO2) {
@@ -284,11 +284,11 @@ object Method extends scalapb.GeneratedMessageCompanion[com.google.protobuf.api.
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = ApiProto.javaDescriptor.getMessageTypes.get(1)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = ApiProto.scalaDescriptor.messages(1)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 6 => __out = com.google.protobuf.`type`.OptionProto
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorRequest.scala
@@ -194,12 +194,12 @@ object CodeGeneratorRequest extends scalapb.GeneratedMessageCompanion[com.google
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = PluginProto.javaDescriptor.getMessageTypes.get(1)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = PluginProto.scalaDescriptor.messages(1)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 15 => __out = com.google.protobuf.descriptor.FileDescriptorProto
       case 3 => __out = com.google.protobuf.compiler.plugin.Version
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/compiler/plugin/CodeGeneratorResponse.scala
@@ -133,11 +133,11 @@ object CodeGeneratorResponse extends scalapb.GeneratedMessageCompanion[com.googl
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = PluginProto.javaDescriptor.getMessageTypes.get(2)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = PluginProto.scalaDescriptor.messages(2)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 15 => __out = com.google.protobuf.compiler.plugin.CodeGeneratorResponse.File
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/DescriptorProto.scala
@@ -324,7 +324,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(2)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(2)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.descriptor.FieldDescriptorProto
       case 6 => __out = com.google.protobuf.descriptor.FieldDescriptorProto
@@ -335,7 +335,7 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
       case 7 => __out = com.google.protobuf.descriptor.MessageOptions
       case 9 => __out = com.google.protobuf.descriptor.DescriptorProto.ReservedRange
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
@@ -481,11 +481,11 @@ object DescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.prot
     def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = com.google.protobuf.descriptor.DescriptorProto.javaDescriptor.getNestedTypes.get(0)
     def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = com.google.protobuf.descriptor.DescriptorProto.scalaDescriptor.nestedMessages(0)
     def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-      var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+      var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
       (__number: @_root_.scala.unchecked) match {
         case 3 => __out = com.google.protobuf.descriptor.ExtensionRangeOptions
       }
-      __out
+      __out.nn
     }
     lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
     def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumDescriptorProto.scala
@@ -203,13 +203,13 @@ object EnumDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(6)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(6)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.descriptor.EnumValueDescriptorProto
       case 3 => __out = com.google.protobuf.descriptor.EnumOptions
       case 4 => __out = com.google.protobuf.descriptor.EnumDescriptorProto.EnumReservedRange
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumOptions.scala
@@ -161,11 +161,11 @@ object EnumOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(14)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(14)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueDescriptorProto.scala
@@ -143,11 +143,11 @@ object EnumValueDescriptorProto extends scalapb.GeneratedMessageCompanion[com.go
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(7)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(7)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 3 => __out = com.google.protobuf.descriptor.EnumValueOptions
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/EnumValueOptions.scala
@@ -136,11 +136,11 @@ object EnumValueOptions extends scalapb.GeneratedMessageCompanion[com.google.pro
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(15)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(15)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ExtensionRangeOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ExtensionRangeOptions.scala
@@ -109,11 +109,11 @@ object ExtensionRangeOptions extends scalapb.GeneratedMessageCompanion[com.googl
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(3)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(3)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldDescriptorProto.scala
@@ -324,11 +324,11 @@ object FieldDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(4)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(4)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 8 => __out = com.google.protobuf.descriptor.FieldOptions
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FieldOptions.scala
@@ -300,11 +300,11 @@ object FieldOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(12)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(12)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorProto.scala
@@ -397,7 +397,7 @@ object FileDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(1)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(1)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 4 => __out = com.google.protobuf.descriptor.DescriptorProto
       case 5 => __out = com.google.protobuf.descriptor.EnumDescriptorProto
@@ -406,7 +406,7 @@ object FileDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google.
       case 8 => __out = com.google.protobuf.descriptor.FileOptions
       case 9 => __out = com.google.protobuf.descriptor.SourceCodeInfo
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileDescriptorSet.scala
@@ -102,11 +102,11 @@ object FileDescriptorSet extends scalapb.GeneratedMessageCompanion[com.google.pr
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(0)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(0)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 1 => __out = com.google.protobuf.descriptor.FileDescriptorProto
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/FileOptions.scala
@@ -627,11 +627,11 @@ object FileOptions extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(10)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(10)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/GeneratedCodeInfo.scala
@@ -107,11 +107,11 @@ object GeneratedCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.pr
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(20)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(20)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 1 => __out = com.google.protobuf.descriptor.GeneratedCodeInfo.Annotation
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MessageOptions.scala
@@ -247,11 +247,11 @@ object MessageOptions extends scalapb.GeneratedMessageCompanion[com.google.proto
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(11)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(11)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodDescriptorProto.scala
@@ -217,11 +217,11 @@ object MethodDescriptorProto extends scalapb.GeneratedMessageCompanion[com.googl
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(9)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(9)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 4 => __out = com.google.protobuf.descriptor.MethodOptions
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/MethodOptions.scala
@@ -158,11 +158,11 @@ object MethodOptions extends scalapb.GeneratedMessageCompanion[com.google.protob
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(17)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(17)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofDescriptorProto.scala
@@ -121,11 +121,11 @@ object OneofDescriptorProto extends scalapb.GeneratedMessageCompanion[com.google
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(5)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(5)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.descriptor.OneofOptions
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/OneofOptions.scala
@@ -109,11 +109,11 @@ object OneofOptions extends scalapb.GeneratedMessageCompanion[com.google.protobu
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(13)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(13)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceDescriptorProto.scala
@@ -147,12 +147,12 @@ object ServiceDescriptorProto extends scalapb.GeneratedMessageCompanion[com.goog
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(8)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(8)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.descriptor.MethodDescriptorProto
       case 3 => __out = com.google.protobuf.descriptor.ServiceOptions
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/ServiceOptions.scala
@@ -136,11 +136,11 @@ object ServiceOptions extends scalapb.GeneratedMessageCompanion[com.google.proto
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(16)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(16)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 999 => __out = com.google.protobuf.descriptor.UninterpretedOption
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/SourceCodeInfo.scala
@@ -147,11 +147,11 @@ object SourceCodeInfo extends scalapb.GeneratedMessageCompanion[com.google.proto
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(19)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(19)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 1 => __out = com.google.protobuf.descriptor.SourceCodeInfo.Location
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/descriptor/UninterpretedOption.scala
@@ -242,11 +242,11 @@ object UninterpretedOption extends scalapb.GeneratedMessageCompanion[com.google.
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = DescriptorProtoCompanion.javaDescriptor.getMessageTypes.get(18)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = DescriptorProtoCompanion.scalaDescriptor.messages(18)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.descriptor.UninterpretedOption.NamePart
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/ListValue.scala
@@ -106,11 +106,11 @@ object ListValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.s
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = StructProto.javaDescriptor.getMessageTypes.get(2)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = StructProto.scalaDescriptor.messages(2)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 1 => __out = com.google.protobuf.struct.Value
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Struct.scala
@@ -117,11 +117,11 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = StructProto.javaDescriptor.getMessageTypes.get(0)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = StructProto.scalaDescriptor.messages(0)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 1 => __out = com.google.protobuf.struct.Struct.FieldsEntry
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] =
     Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]](
@@ -240,11 +240,11 @@ object Struct extends scalapb.GeneratedMessageCompanion[com.google.protobuf.stru
     def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = com.google.protobuf.struct.Struct.javaDescriptor.getNestedTypes.get(0)
     def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = com.google.protobuf.struct.Struct.scalaDescriptor.nestedMessages(0)
     def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-      var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+      var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
       (__number: @_root_.scala.unchecked) match {
         case 2 => __out = com.google.protobuf.struct.Value
       }
-      __out
+      __out.nn
     }
     lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
     def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Value.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/struct/Value.scala
@@ -202,12 +202,12 @@ object Value extends scalapb.GeneratedMessageCompanion[com.google.protobuf.struc
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = StructProto.javaDescriptor.getMessageTypes.get(1)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = StructProto.scalaDescriptor.messages(1)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 5 => __out = com.google.protobuf.struct.Struct
       case 6 => __out = com.google.protobuf.struct.ListValue
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Enum.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Enum.scala
@@ -217,13 +217,13 @@ object Enum extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type`
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = TypeProto.javaDescriptor.getMessageTypes.get(2)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = TypeProto.scalaDescriptor.messages(2)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.`type`.EnumValue
       case 3 => __out = com.google.protobuf.`type`.OptionProto
       case 4 => __out = com.google.protobuf.source_context.SourceContext
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/EnumValue.scala
@@ -164,11 +164,11 @@ object EnumValue extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = TypeProto.javaDescriptor.getMessageTypes.get(3)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = TypeProto.scalaDescriptor.messages(3)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 3 => __out = com.google.protobuf.`type`.OptionProto
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Field.scala
@@ -376,11 +376,11 @@ object Field extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = TypeProto.javaDescriptor.getMessageTypes.get(1)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = TypeProto.scalaDescriptor.messages(1)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 9 => __out = com.google.protobuf.`type`.OptionProto
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/OptionProto.scala
@@ -139,11 +139,11 @@ object OptionProto extends scalapb.GeneratedMessageCompanion[com.google.protobuf
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = TypeProto.javaDescriptor.getMessageTypes.get(4)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = TypeProto.scalaDescriptor.messages(4)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.any.Any
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)

--- a/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Type.scala
+++ b/scalapb-runtime/jvm/src/main/scala/com/google/protobuf/type/Type.scala
@@ -242,13 +242,13 @@ object Type extends scalapb.GeneratedMessageCompanion[com.google.protobuf.`type`
   def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = TypeProto.javaDescriptor.getMessageTypes.get(0)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = TypeProto.scalaDescriptor.messages(0)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
-    var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null
+    var __out: _root_.scalapb.GeneratedMessageCompanion[_] | Null = null
     (__number: @_root_.scala.unchecked) match {
       case 2 => __out = com.google.protobuf.`type`.Field
       case 4 => __out = com.google.protobuf.`type`.OptionProto
       case 5 => __out = com.google.protobuf.source_context.SourceContext
     }
-    __out
+    __out.nn
   }
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = {

--- a/scalapb-runtime/shared/src/main/scala/scalapb/AnyMethods.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/AnyMethods.scala
@@ -18,7 +18,7 @@ trait AnyMethods {
 
 object AnyMethods {
   private def typeNameFromTypeUrl(typeUrl: String): String = {
-    typeUrl.split("/").lastOption.getOrElse(typeUrl)
+    typeUrl.split("/").lastOption.getOrElse(typeUrl).nn
   }
 }
 

--- a/scalapb-runtime/shared/src/main/scala/scalapb/FieldMaskUtil.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/FieldMaskUtil.scala
@@ -54,12 +54,12 @@ object FieldMaskUtil {
     }
 
     val array = name.split("\\_")
-    toLowerCase(array(0), buf)
+    toLowerCase(array(0).nn, buf)
 
     @tailrec
     def loop(i: Int): Unit = {
       if (i < array.length) {
-        toProperCase(array(i))
+        toProperCase(array(i).nn)
         loop(i + 1)
       }
     }
@@ -114,9 +114,9 @@ object FieldMaskUtil {
     val result = value
       .split(",")
       .toIterator
-      .withFilter(_.nonEmpty)
+      .withFilter(_.nn.nonEmpty)
       .map { path =>
-        camelCaseToSnakeCase(path)
+        camelCaseToSnakeCase(path.nn)
       }
       .toList
     FieldMask(result)

--- a/scalapb-runtime/shared/src/main/scala/scalapb/LimitedInputStream.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/LimitedInputStream.scala
@@ -20,7 +20,7 @@ class LimitedInputStream(val is: InputStream, private var limit: Int)
       result
     }
 
-  override def read(bytes: Array[Byte] | JavaNull, off: Int, len: Int): Int =
+  override def read(bytes: Array[Byte] | Null, off: Int, len: Int): Int =
     if (limit <= 0) {
       -1
     } else {

--- a/scalapb-runtime/shared/src/main/scala/scalapb/LimitedInputStream.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/LimitedInputStream.scala
@@ -20,7 +20,7 @@ class LimitedInputStream(val is: InputStream, private var limit: Int)
       result
     }
 
-  override def read(bytes: Array[Byte], off: Int, len: Int): Int =
+  override def read(bytes: Array[Byte] | JavaNull, off: Int, len: Int): Int =
     if (limit <= 0) {
       -1
     } else {

--- a/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalapbProto.scala
+++ b/scalapb-runtime/shared/src/main/scala/scalapb/options/ScalapbProto.scala
@@ -63,7 +63,7 @@ object ScalapbProto extends _root_.scalapb.GeneratedFileObject {
   }
   lazy val javaDescriptor: com.google.protobuf.Descriptors.FileDescriptor = {
     val javaProto = com.google.protobuf.DescriptorProtos.FileDescriptorProto.parseFrom(ProtoBytes)
-    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array(
+    com.google.protobuf.Descriptors.FileDescriptor.buildFrom(javaProto, Array[com.google.protobuf.Descriptors.FileDescriptor | Null](
       com.google.protobuf.descriptor.DescriptorProtoCompanion.javaDescriptor
     ))
   }


### PR DESCRIPTION
Passes tests. 

LOC changed: 23
In Google Protobuf: 70

**Java method returns array** | 7
A java method returns an array with type `[T|Null]` instead of `[T]`.

**Pass array into Java method** | 1
A java method requires an array as a parameter with inner types `[T | Null]`.

**Overridden java method arguments are nullable** | 14
A java method requires parameter of type `T | Null` for override. 

**Needs a fix to standard library** | 1
Problems with `Option`.

---

The following changes are in the google protobuf changes, and thus are not counted in the main code:

**Can actually be null** | 35 * 2 = 70
Pairs of line changes. One for variable declaration, and another for return non-null.
